### PR TITLE
Support for Video and audio user access .

### DIFF
--- a/Containerfile.rootfs.20_04
+++ b/Containerfile.rootfs.20_04
@@ -86,7 +86,7 @@ COPY config/netcfg.yaml /etc/netplan/netcfg.yaml
 # password: jetson
 RUN useradd \
         --create-home \
-        -G sudo \
+        -G sudo,video,audio \
         -p $(openssl passwd -6 jetson) \
         -s /bin/bash \
         jetson

--- a/Containerfile.rootfs.22_04
+++ b/Containerfile.rootfs.22_04
@@ -92,7 +92,7 @@ COPY config/netcfg.yaml /etc/netplan/netcfg.yaml
 # password: jetson
 RUN useradd \
         --create-home \
-        -G sudo \
+        -G sudo,video,audio \
         -p $(openssl passwd -6 jetson) \
         -s /bin/bash \
         jetson


### PR DESCRIPTION
You need to add the Video groups so that an interface can be access set up when logging into Desktop
Without the audio group you will not detect sound on the device by any app .