### PR TITLE
Rename cuda_toolkit package for r32

### DIFF
--- a/Containerfile.image.l4t32
+++ b/Containerfile.image.l4t32
@@ -50,7 +50,7 @@ RUN chroot /build/Linux_for_Tegra/rootfs/ /bin/bash -c "chown -R jetson:jetson /
 RUN mount -t proc proc rootfs/proc/ && \
     mount -t sysfs sys rootfs/sys && \
     mount -o bind /dev rootfs/dev && \
-    chroot rootfs /bin/bash -c "echo 'nameserver 8.8.8.8' > /etc/resolv.conf && apt update; apt install -y cuda-toolkit $L4T_PACKAGES"
+    chroot rootfs /bin/bash -c "echo 'nameserver 8.8.8.8' > /etc/resolv.conf && apt update; apt install -y cuda-toolkit-10-2 $L4T_PACKAGES"
 
 # Edit initrd
 WORKDIR /tmp/pythops


### PR DESCRIPTION
Fixes #137

The problem was in a different package name for `cuda_toolkit` for r32.

I cannot reproduce the second issue mentioned in the ticket - `losetup: system.img: failed to set up loop device`. It is possible that it has been resolved upstream.