### PR TITLE
workaround for libc error on ubuntu 22.04 build #144

### DIFF
--- a/Containerfile.rootfs.22_04
+++ b/Containerfile.rootfs.22_04
@@ -6,6 +6,11 @@ LABEL org.opencontainers.image.authors="Badr @pythops"
 RUN echo "deb http://ports.ubuntu.com/ubuntu-ports/ focal main" >> /etc/apt/sources.list  && \
     apt update
 
+RUN rm /var/lib/dpkg/info/libc-bin.* && \ 
+    apt-get clean && \
+    apt-get update && \
+    apt-get install libc-bin
+
 # Nvidia required packages
 RUN apt install -y \
         libgles2 \


### PR DESCRIPTION
reference:
https://stackoverflow.com/questions/73710118/trying-to-update-libc-bin-error-state-134-cant-sudo-install-net-tools/76260513#76260513 https://stackoverflow.com/questions/78105004/docker-build-fails-because-unable-to-install-libc-bin