### PR TITLE
use the host network to avoid proxy/vpn setup in some corpnet

### DIFF
--- a/scripts/build-base-rootfs.sh
+++ b/scripts/build-base-rootfs.sh
@@ -17,6 +17,7 @@ case $1 in
     --squash-all \
     --jobs=4 \
     --arch=arm64 \
+    --network=host \
     -f Containerfile.rootfs.20_04 \
     -t jetson-rootfs
   ;;
@@ -26,6 +27,7 @@ case $1 in
     --squash-all \
     --jobs=4 \
     --arch=arm64 \
+    --network=host \
     -f Containerfile.rootfs.22_04 \
     -t jetson-rootfs
   ;;
@@ -35,6 +37,7 @@ case $1 in
     --squash-all \
     --jobs=4 \
     --arch=arm64 \
+    --network=host \
     -f Containerfile.rootfs.24_04 \
     -t jetson-rootfs
   ;;

--- a/scripts/build-jetson-image.sh
+++ b/scripts/build-jetson-image.sh
@@ -146,12 +146,14 @@ L4T_PACKAGES="${L4T_PACKAGES# }"
 sudo -E XDG_RUNTIME_DIR= DBUS_SESSION_BUS_ADDRESS= podman build \
     --cap-add=all \
     --jobs=4 \
+    --network=host \
     --build-arg L4T_PACKAGES="$L4T_PACKAGES" \
     -f Containerfile.image.l4t"$l4t" \
     -t jetson-build-image-l4t"$l4t"
 
 sudo podman run \
     --rm \
+    --network=host \
     --privileged \
     -v .:/jetson \
     -e JETSON_BOARD="$board" \


### PR DESCRIPTION
couple company requires specific VPN or proxy to access the external network. use `--network=host` to avoid complex setup on containers.