### PR TITLE
MUS-7337 find diff on system img old file vs the one is being built by ci cd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,31 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
+    docker:
+      # Specify the version you desire here
+      # See: https://circleci.com/developer/images/image/cimg/base
+      - image: cimg/base:current
+
+    # Add steps to the job
+    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
+    steps:
+      # Checkout the code as the first step.
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Orchestrate jobs using workflows
+# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
+workflows:
+  say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
+    # Inside the workflow, you define the jobs you want to run.
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,6 @@ jobs:
 workflows:
   trigger-murine-os-build-workflow:
     jobs:
-      - trigger-murine-os-build
-      context:
-        - murine-os
+      - trigger-murine-os-build:
+          context: 
+            - murine-os

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,10 @@ jobs:
           name: "Trigger murine-os build"
           command: |
             curl -X POST https://circleci.com/api/v2/project/github/murine-org/murine/pipeline \
-              -H "Circle-Token: $PERSONAL_ACCESS_TOKEN_RAJ" \
+              -H "Circle-Token: $CIRCLECI_PAT" \
               -H "Content-Type: application/json" \
               -d '{
-                    "branch": "develop",
+                    "branch": "MUS-5876-murine-os-deployments",
                     "parameters": {
                       "continuation-params": "{\"run-setup\": false}",
                       "modules": "dax/os_image_creation",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
                     "parameters": {
                       "continuation-params": "{\"run-setup\": false}",
                       "modules": "dax/os_image_creation",
-                      "force-all": "true"
+                      "force-all": true
                     }
                   }'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
               -H "Circle-Token: $CIRCLECI_PAT" \
               -H "Content-Type: application/json" \
               -d '{
-                    "branch": "MUS-5876-murine-os-deployments",
+                    "branch": "develop",
                     "parameters": {
                       "continuation-params": "{\"api-exclusive-build\": true, \"run-setup\": false}",
                       "modules": "dax/os_image_creation",

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,10 @@ jobs:
       - run:
           name: "Run Murine OS build"
           command: |
-            pip3 install --no-deps --use-pep517 -e ./iot_shared
             git clone git@github.com:murine-org/jetson-image.git $HOME/jetson-image
             git clone git@github.com:murine-org/ops-ansible.git $HOME/ops-ansible
             git clone git@github.com:murine-org/murine.git $HOME/murine
+            pip3 install --no-deps --use-pep517 -e $HOME/murine/iot_shared
             sudo python3 $HOME/murine/dax/os_image_creation/immutable/scripts/make_squashfs.py \
               --jetson $HOME/jetson-image \
               --ops $HOME/ops-ansible \
@@ -87,7 +87,7 @@ workflows:
         - equal: [ << pipeline.git.branch >>, MUS-5876-murine-cicd ]
     jobs:
       - murine-os-build:
-          name: "Murine OS Build on dev"
+          name: "Murine OS Build"
           context:
             - aws
             - murine-os

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
               -d '{
                     "branch": "MUS-5876-murine-os-deployments",
                     "parameters": {
-                      "continuation-params": "{\"run-setup\": false}",
+                      "continuation-params": "{\"api-exclusive-build\": true}",
                       "modules": "dax/os_image_creation",
                       "force-all": true
                     }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,3 +27,8 @@ workflows:
       - trigger-murine-os-build:
           context: 
             - murine-os
+          filters:
+            branches:
+              only:
+                - master
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
               -d '{
                     "branch": "MUS-5876-murine-os-deployments",
                     "parameters": {
-                      "continuation-params": "{\"api-exclusive-build\": true}",
+                      "continuation-params": "{\"api-exclusive-build\": true, \"run-setup\": false}",
                       "modules": "dax/os_image_creation",
                       "force-all": true
                     }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,93 +1,29 @@
 version: 2.1
 
-orbs:
-  aws-cli: circleci/aws-cli@2.0.6
-
-parameters:
-  api_exclusive_build:
-    type: boolean
-    default: false
-
 jobs:
-  murine-os-build:
-    machine:
-      image: ubuntu-2204:2024.01.1
-    environment:
-      KERNEL_VERSION: "4.9.201-murine"
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "b8:58:d9:0a:31:5f:80:38:6e:cc:36:43:17:26:24:8a"
-
-      - run:
-          name: "Setup keys & install dependencies"
-          command: |
-            mkdir -p "$HOME/.ssh"
-            echo "$DEVICE_MASTER_KEY_PUB" > "$HOME/.ssh/dax-master.key.pub"
-            echo "$DEVICE_VISITOR_KEY_PUB" >> "$HOME/.ssh/visitor.key.pub"
-            sudo apt-get update --fix-missing
-            sudo apt-get install -y podman android-sdk-libsparse-utils qemu-user-static qemu-user
-
-      - run:
-          name: "Run Murine OS build"
-          command: |
-            git clone git@github.com:murine-org/jetson-image.git $HOME/jetson-image
-            git clone git@github.com:murine-org/ops-ansible.git $HOME/ops-ansible
-            git clone git@github.com:murine-org/murine.git $HOME/murine
-            pip3 install --no-deps --use-pep517 -e $HOME/murine/iot_shared
-            sudo python3 $HOME/murine/dax/os_image_creation/immutable/scripts/make_squashfs.py \
-              --jetson $HOME/jetson-image \
-              --ops $HOME/ops-ansible \
-              --kernel "$KERNEL_VERSION" \
-              --public $HOME/.ssh/dax-master.key.pub \
-              --ssh-user murine \
-              --ssh-public $HOME/.ssh/visitor.key.pub \
-              --output $HOME/out/
-
-      - run:
-          name: "Verify and Upload binaries to S3"
-          command: |
-            FILE_PATH="$HOME/out/$KERNEL_VERSION/root-$KERNEL_VERSION.squashfs"
-            if [ ! -f "$FILE_PATH" ]; then
-              echo "❌ Error: Expected binary file not created: $FILE_PATH"
-              exit 1
-            fi
-            cd $HOME/murine/dax/os_image_creation
-            make rootfs-push-s3 ROOT_FS_PATH="$FILE_PATH" ENV="$ENV"
-
-      - run:
-          name: "Create a package and push"
-          command: |
-            sudo apt-get update --fix-missing
-            sudo apt-get install -y p7zip-full
-            echo -e "$DEVICE_MASTER_KEY" >> "$HOME/.ssh/dax-master.key"
-            pip3 install pyjwt boto3 cryptography
-            cd $HOME/murine/dax/os_image_creation
-            make murineos-package-push RootFS="$FILE_PATH" \
-              DEVICE_PRIVATE_KEY="$HOME/.ssh/dax-master.key" ENV="$ENV"
-
-  murine-os-tag-prod-release:
+  trigger-murine-os-build:
     resource_class: small
-    machine:
-      image: ubuntu-2204:2024.01.1
+    docker:
+      - image: cimg/base:current
     steps:
-      - checkout
-      - aws-cli/setup
       - run:
-          name: "Tag the latest package with stable"
+          name: "Trigger murine-os build"
           command: |
-            make murineos-tag-stable-release
-
+            curl -X POST https://circleci.com/api/v2/project/github/murine-org/murine/pipeline \
+              -H "Circle-Token: $PERSONAL_ACCESS_TOKEN_RAJ" \
+              -H "Content-Type: application/json" \
+              -d '{
+                    "branch": "develop",
+                    "parameters": {
+                      "continuation-params": "{\"run-setup\": false}",
+                      "modules": "dax/os_image_creation",
+                      "force-all": "true"
+                    }
+                  }'
 
 workflows:
-  murine-os-build-api-workflow:
-    when:
-      or:
-        - equal: [ << pipeline.parameters.api_exclusive_build >>, true ]
-        - equal: [ << pipeline.git.branch >>, MUS-5876-murine-cicd ]
+  trigger-murine-os-build-workflow:
     jobs:
-      - murine-os-build:
-          name: "Murine OS Build"
-          context:
-            - aws
+      - trigger-murine-os-build:
+          context: 
             - murine-os

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,27 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/configuration-reference
 version: 2.1
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/jobs-steps/#jobs-overview & https://circleci.com/docs/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Docker Hub or use one of our convenience images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/executor-intro/ & https://circleci.com/docs/configuration-reference/#executor-job
+  trigger-murine-os-build:
     docker:
-      # Specify the version you desire here
-      # See: https://circleci.com/developer/images/image/cimg/base
       - image: cimg/base:current
 
-    # Add steps to the job
-    # See: https://circleci.com/docs/jobs-steps/#steps-overview & https://circleci.com/docs/configuration-reference/#steps
     steps:
-      # Checkout the code as the first step.
-      - checkout
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          name: "Trigger murine-os build"
+          command: |
+            curl -X POST https://circleci.com/api/v2/project/github/murine-org/murine/pipeline \
+              -H "Circle-Token: $MURINE_PROJECT_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d '{
+                    "branch": "MUS-5876-murine-os-deployments",
+                    "parameters": {
+                      "target_env": "aws"
+                    }
+                  }'
 
-# Orchestrate jobs using workflows
-# See: https://circleci.com/docs/workflows/ & https://circleci.com/docs/configuration-reference/#workflows
 workflows:
-  say-hello-workflow: # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run.
+  trigger-murine-os-build-workflow:
     jobs:
-      - say-hello
+      - trigger-murine-os-build
+      context:
+        - murine-os

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,93 @@
 version: 2.1
 
-jobs:
-  trigger-murine-os-build:
-    docker:
-      - image: cimg/base:current
+orbs:
+  aws-cli: circleci/aws-cli@2.0.6
 
+parameters:
+  api_exclusive_build:
+    type: boolean
+    default: false
+
+jobs:
+  murine-os-build:
+    machine:
+      image: ubuntu-2204:2024.01.1
+    environment:
+      KERNEL_VERSION: "4.9.201-murine"
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "b8:58:d9:0a:31:5f:80:38:6e:cc:36:43:17:26:24:8a"
+
       - run:
-          name: "Trigger murine-os build"
+          name: "Setup keys & install dependencies"
           command: |
-            curl -X POST https://circleci.com/api/v2/project/github/murine-org/murine/pipeline \
-              -H "Circle-Token: $MURINE_PROJECT_API_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d '{
-                    "branch": "MUS-5876-murine-os-deployments",
-                    "parameters": {
-                      "target_env": "aws"
-                    }
-                  }'
+            mkdir -p "$HOME/.ssh"
+            echo "$DEVICE_MASTER_KEY_PUB" > "$HOME/.ssh/dax-master.key.pub"
+            echo "$DEVICE_VISITOR_KEY_PUB" >> "$HOME/.ssh/visitor.key.pub"
+            sudo apt-get update --fix-missing
+            sudo apt-get install -y podman android-sdk-libsparse-utils qemu-user-static qemu-user
+
+      - run:
+          name: "Run Murine OS build"
+          command: |
+            pip3 install --no-deps --use-pep517 -e ./iot_shared
+            git clone git@github.com:murine-org/jetson-image.git $HOME/jetson-image
+            git clone git@github.com:murine-org/ops-ansible.git $HOME/ops-ansible
+            git clone git@github.com:murine-org/murine.git $HOME/murine
+            sudo python3 $HOME/murine/dax/os_image_creation/immutable/scripts/make_squashfs.py \
+              --jetson $HOME/jetson-image \
+              --ops $HOME/ops-ansible \
+              --kernel "$KERNEL_VERSION" \
+              --public $HOME/.ssh/dax-master.key.pub \
+              --ssh-user murine \
+              --ssh-public $HOME/.ssh/visitor.key.pub \
+              --output $HOME/out/
+
+      - run:
+          name: "Verify and Upload binaries to S3"
+          command: |
+            FILE_PATH="$HOME/out/$KERNEL_VERSION/root-$KERNEL_VERSION.squashfs"
+            if [ ! -f "$FILE_PATH" ]; then
+              echo "❌ Error: Expected binary file not created: $FILE_PATH"
+              exit 1
+            fi
+            cd $HOME/murine/dax/os_image_creation
+            make rootfs-push-s3 ROOT_FS_PATH="$FILE_PATH" ENV="$ENV"
+
+      - run:
+          name: "Create a package and push"
+          command: |
+            sudo apt-get update --fix-missing
+            sudo apt-get install -y p7zip-full
+            echo -e "$DEVICE_MASTER_KEY" >> "$HOME/.ssh/dax-master.key"
+            pip3 install pyjwt boto3 cryptography
+            cd $HOME/murine/dax/os_image_creation
+            make murineos-package-push RootFS="$FILE_PATH" \
+              DEVICE_PRIVATE_KEY="$HOME/.ssh/dax-master.key" ENV="$ENV"
+
+  murine-os-tag-prod-release:
+    resource_class: small
+    machine:
+      image: ubuntu-2204:2024.01.1
+    steps:
+      - checkout
+      - aws-cli/setup
+      - run:
+          name: "Tag the latest package with stable"
+          command: |
+            make murineos-tag-stable-release
+
 
 workflows:
-  trigger-murine-os-build-workflow:
+  murine-os-build-api-workflow:
+    when:
+      or:
+        - equal: [ << pipeline.parameters.api_exclusive_build >>, true ]
+        - equal: [ << pipeline.git.branch >>, MUS-5876-murine-cicd ]
     jobs:
-      - trigger-murine-os-build:
-          context: 
+      - murine-os-build:
+          name: "Murine OS Build on dev"
+          context:
+            - aws
             - murine-os

--- a/Containerfile.image.l4t32
+++ b/Containerfile.image.l4t32
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 LABEL org.opencontainers.image.authors="Badr @pythops"
 
 # Define the BSP version
-ARG BSP=https://developer.download.nvidia.com/embedded/L4T/r32_Release_v7.4/T210/Jetson-210_Linux_R32.7.4_aarch64.tbz2
+ARG BSP=https://developer.nvidia.com/embedded/L4T/r32_Release_v5.0/T210/Tegra210_Linux_R32.5.0_aarch64.tbz2
 
 # Install different dependencies
 RUN apt update && \

--- a/Containerfile.image.l4t32
+++ b/Containerfile.image.l4t32
@@ -3,7 +3,7 @@ FROM ubuntu:jammy
 LABEL org.opencontainers.image.authors="Badr @pythops"
 
 # Define the BSP version
-ARG BSP=https://developer.nvidia.com/embedded/L4T/r32_Release_v5.0/T210/Tegra210_Linux_R32.5.0_aarch64.tbz2
+ARG BSP=https://developer.nvidia.com/embedded/l4t/r32_release_v5.1/r32_release_v5.1/t210/jetson-210_linux_r32.5.1_aarch64.tbz2
 
 # Install different dependencies
 RUN apt update && \

--- a/Containerfile.rootfs.20_04
+++ b/Containerfile.rootfs.20_04
@@ -39,36 +39,25 @@ RUN apt install -y \
         i2c-tools \
         bridge-utils
 
-# Additional tools
+# Additional tools   
 RUN apt install -y \
-        bash-completion \
-        build-essential \
-        btrfs-progs \
-        cmake \
-        curl \
-        dnsutils \
-        htop \
-        iotop \
-        isc-dhcp-client \
-        iputils-ping \
-        kmod \
-        linux-firmware \
-        locales \
-        net-tools \
-        netplan.io \
-        pciutils \
-        python3-dev \
-        ssh \
-        sudo \
-        udev \
-        unzip \
-        usbutils \
-        neovim \
-        wpasupplicant \
-        parted \
-        gdisk \
-        e2fsprogs \
-        mtd-utils
+    curl \
+    e2fsprogs \
+    gdisk \
+    iputils-ping \
+    kmod \
+    linux-firmware \
+    locales \
+    netplan.io \
+    parted \
+    ssh \
+    sudo \
+    udev \
+    unzip \
+    usbutils \
+    wpasupplicant && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Resize the rootfs
 COPY scripts/resizerootfs.sh /usr/local/bin

--- a/scripts/create-jetson-image.sh
+++ b/scripts/create-jetson-image.sh
@@ -14,6 +14,7 @@ jetson-nano)
     printf "Creating image for Jetson nano board (%s revision) \n" "$JETSON_REVISION"
     sudo ./jetson-disk-image-creator.sh -o jetson.img -b jetson-nano -r "$JETSON_REVISION"
     cp jetson.img /jetson/
+    cp /build/Linux_for_Tegra/bootloader/system.img /jetson/
     printf "[OK]\n"
     ;;
 


### PR DESCRIPTION
Description:
This PR removes non-essential packages from the rootfs used to build system.img, resulting in a significantly lighter image.

Changes:

- Removed development tools (build-essential, cmake, python3-dev, etc.)
- Removed debugging utilities (htop, iotop, dnsutils, etc.)
- Retained only core packages required for boot, networking, SSH, and binary application (apply_binaries.sh)