### PR TITLE
#150 - feat: add support for Jetson Orin Nano Super board

### DIFF
--- a/scripts/create-jetson-image.sh
+++ b/scripts/create-jetson-image.sh
@@ -24,6 +24,13 @@ jetson-orin-nano)
     printf "[OK]\n"
     ;;
 
+jetson-orin-nano-super)
+    printf "Creating image for Jetson orin nano board (SUPER variant) \n"
+    sudo ./jetson-disk-image-creator.sh -o jetson.img -b jetson-orin-nano-devkit-super -d "$JETSON_DEVICE"
+    cp jetson.img /jetson/
+    printf "[OK]\n"
+    ;;
+
 jetson-xavier-nx)
     printf "Creating image for Jetson xavier nx board \n"
     sudo ./jetson-disk-image-creator.sh -o jetson.img -b jetson-xavier-nx-devkit -d "$JETSON_DEVICE"


### PR DESCRIPTION
Related to #150  - Confirmed this is working on the Orin Super board variant.

- Add `jetson-orin-nano-super` board variant to `create-jetson-image.sh`
- Uses `jetson-orin-nano-devkit-super` identifier for BSP
- Follows same pattern as jetson-orin-nano for device parameter handling

There is still a post-configuration needed to get the benefits enabled, but not sure where that would go in your setup - maybe a conditional argument in the docker files? I didn't want to mess up your clean flow with these files, so will lean on you to the proper location.

```bash
# 1. Permanently set the default power mode to MAXN_SUPER (ID=2)
sudo sed -i 's/< PM_CONFIG DEFAULT=.*/< PM_CONFIG DEFAULT=2 >/g' /etc/nvpmodel.conf

# 2. Permanently lock all clocks to maximum (this is what jetson_clocks --store does)
sudo /usr/bin/jetson_clocks --store
```

also may require an adjustment to the extlinux.conf

```bash
cat > "${ROOTFS_PATH}/boot/extlinux/extlinux.conf" << 'EOF'
TIMEOUT 30
DEFAULT SuperMode

MENU TITLE L4T boot options

LABEL SuperMode
      MENU LABEL Super: <Super Mode>
      LINUX /boot/Image
      FDT /boot/dtb/kernel_tegra234-p3768-0000+p3767-0005-nv-super.dtb
      INITRD /boot/initrd
      APPEND ${cbootargs} root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 firmware_class.path=/etc/firmware fbcon=map:0 video=efifb:off console=tty0

LABEL NoOverlay
      MENU LABEL Standard Config: <No Overlay>
      LINUX /boot/Image
      INITRD /boot/initrd
      APPEND ${cbootargs} root=/dev/mmcblk0p1 rw rootwait rootfstype=ext4 mminit_loglevel=4 console=ttyTCU0,115200 firmware_class.path=/etc/firmware fbcon=map:0 video=efifb:off console=tty0      
EOF
```

Not sure where you would want those either, but the menu option to build the super is required to get the proper dtb file for super mode.

Can be validated its in super mode

```bash
printf "Super mode: %s | EMC_CAP %.1f GHz\n" \
  "$(nvpmodel -q | grep -q MAXN_SUPER && echo YES || echo NO)" \
  "$(cat /sys/kernel/nvpmodel_clk_cap/emc 2>/dev/null || echo 0 | awk '{printf \"%.1f\", $1/1000000000}')"
```
```bash
Super mode: YES | EMC_CAP 3199000000.0 GHz
```

I am running this successfully in the Ubuntu 24 image. I did not validate anything else, but guessing it would be fine, as this isnt OS specific, its just hardware control. 